### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/857/648/77/85764877.geojson
+++ b/data/857/648/77/85764877.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1082751
     },
     "wof:country":"GF",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2189095600c38dca86a79bdf68c659f",
     "wof:hierarchy":[
         {
@@ -103,7 +107,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566637419,
+    "wof:lastmodified":1582343959,
     "wof:name":"Cit\u00e9 C\u00e9saire",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/83/85764883.geojson
+++ b/data/857/648/83/85764883.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":300173
     },
     "wof:country":"GF",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"30ec218e9d3e48a11897c76f10ab97bc",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566637419,
+    "wof:lastmodified":1582343959,
     "wof:name":"\u00celet Malouin",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/87/85764887.geojson
+++ b/data/857/648/87/85764887.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":1165380
     },
     "wof:country":"GF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b247ec11406ac4bb01f53e1404ec1bb6",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566637419,
+    "wof:lastmodified":1582343959,
     "wof:name":"Les Roches",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/89/85764889.geojson
+++ b/data/857/648/89/85764889.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":240975
     },
     "wof:country":"GF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40766910a586587151037b745ef7fb92",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566637419,
+    "wof:lastmodified":1582343959,
     "wof:name":"Moyoco",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/93/85764893.geojson
+++ b/data/857/648/93/85764893.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1165381
     },
     "wof:country":"GF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b25175aa730968d989f5f5d249250f0f",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566637419,
+    "wof:lastmodified":1582343958,
     "wof:name":"Village Br\u00e9silien",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/648/95/85764895.geojson
+++ b/data/857/648/95/85764895.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":893984
     },
     "wof:country":"GF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5a3b5cdbda0dd38c8cd7bb87e2566b7",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566637418,
+    "wof:lastmodified":1582343958,
     "wof:name":"Village Saramaka",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.