### PR TITLE
gf concordances, placetype local, and more

### DIFF
--- a/data/110/880/592/9/1108805929.geojson
+++ b/data/110/880/592/9/1108805929.geojson
@@ -147,6 +147,7 @@
         "hasc:id":"GF.CY",
         "wd:id":"Q672744"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GF",
     "wof:created":1485971832,
     "wof:geomhash":"d322e86d92c1fceac7b28cbc7ab887a5",
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108805929,
-    "wof:lastmodified":1695885816,
+    "wof:lastmodified":1696023154,
     "wof:name":"Cayenne",
     "wof:parent_id":85671195,
     "wof:placetype":"macrocounty",

--- a/data/110/880/592/9/1108805929.geojson
+++ b/data/110/880/592/9/1108805929.geojson
@@ -165,7 +165,7 @@
         }
     ],
     "wof:id":1108805929,
-    "wof:lastmodified":1694493034,
+    "wof:lastmodified":1695885816,
     "wof:name":"Cayenne",
     "wof:parent_id":85671195,
     "wof:placetype":"macrocounty",

--- a/data/110/880/593/3/1108805933.geojson
+++ b/data/110/880/593/3/1108805933.geojson
@@ -156,6 +156,7 @@
         "hasc:id":"GF.SL",
         "wd:id":"Q692903"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GF",
     "wof:created":1485971834,
     "wof:geomhash":"7562cf3c5add1d725b7e0d0f68026fad",
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108805933,
-    "wof:lastmodified":1695885846,
+    "wof:lastmodified":1696023154,
     "wof:name":"Saint-Laurent-du-Maroni",
     "wof:parent_id":85671195,
     "wof:placetype":"macrocounty",

--- a/data/110/880/593/3/1108805933.geojson
+++ b/data/110/880/593/3/1108805933.geojson
@@ -174,7 +174,7 @@
         }
     ],
     "wof:id":1108805933,
-    "wof:lastmodified":1694493037,
+    "wof:lastmodified":1695885846,
     "wof:name":"Saint-Laurent-du-Maroni",
     "wof:parent_id":85671195,
     "wof:placetype":"macrocounty",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.